### PR TITLE
use appropriate cookies library for client-side renders

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -4,9 +4,10 @@ import type { FunctionComponent } from 'react'
 
 import { useRouter } from 'next/navigation'
 import { useEffect, useState, useRef, useCallback } from 'react'
-import { cookies } from 'next/headers'
 
 import styles from './page.module.css'
+
+import { useAuth } from '@hooks'
 
 const Page: FunctionComponent = () => {
     const [ throttle, setThrottle ] = useState<boolean>(false)
@@ -24,7 +25,7 @@ const Page: FunctionComponent = () => {
     const [ username, setUsername ] = useState<string>('')
     const [ password, setPassword ] = useState<string>('')
 
-    const storage = cookies()
+    const { setToken } = useAuth()
 
     const login = async () => {
         try {
@@ -42,10 +43,8 @@ const Page: FunctionComponent = () => {
             if (!response.ok) {
                 throw new Error('')
             }
-
-            const token = response.headers.get('Authorization')!.split(' ')[1]
-
-            storage.set('algurado/token', token)
+            
+            setToken(response.headers.get('Authorization')!.split(' ')[1])
             router.push('/dashboard')
         } catch (error) {}
     }

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState, useRef, useCallback } from 'react'
 
 import styles from './page.module.css'
 
-import { useToken } from '@hooks'
+import { useToken, useUser } from '@hooks'
 
 const Page: FunctionComponent = () => {
     const [ throttle, setThrottle ] = useState<boolean>(false)
@@ -25,6 +25,7 @@ const Page: FunctionComponent = () => {
     const [ username, setUsername ] = useState<string>('')
     const [ password, setPassword ] = useState<string>('')
 
+    const { setUser } = useUser()
     const { setToken } = useToken()
 
     const login = async () => {
@@ -45,6 +46,7 @@ const Page: FunctionComponent = () => {
             }
             
             setToken(response.headers.get('Authorization')!.split(' ')[1])
+            setUser(await response.json())
             router.push('/dashboard')
         } catch (error) {}
     }

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState, useRef, useCallback } from 'react'
 
 import styles from './page.module.css'
 
-import { useAuth } from '@hooks'
+import { useToken } from '@hooks'
 
 const Page: FunctionComponent = () => {
     const [ throttle, setThrottle ] = useState<boolean>(false)
@@ -25,7 +25,7 @@ const Page: FunctionComponent = () => {
     const [ username, setUsername ] = useState<string>('')
     const [ password, setPassword ] = useState<string>('')
 
-    const { setToken } = useAuth()
+    const { setToken } = useToken()
 
     const login = async () => {
         try {

--- a/app/_hooks/auth/index.tsx
+++ b/app/_hooks/auth/index.tsx
@@ -76,14 +76,9 @@ export const useAuth = () => {
         validate()
     }, [ token ])
 
-    const getUser = async () => {
-        await validate()
-
-        return user
-    }
-
     return {
-        getUser,
+        user,
+        validate,
         setToken,
     }
 }

--- a/app/_hooks/auth/index.tsx
+++ b/app/_hooks/auth/index.tsx
@@ -71,23 +71,19 @@ const validate = async () => {
 export const useAuth = () => {
     const { user } = useUser()
     const { token, setToken } = useToken()
-    const [ shouldCheck, setShouldCheck ] = useState<boolean>(false)
 
     useEffect(() => {
         validate()
     }, [ token ])
 
-    useEffect(() => {
-        if (shouldCheck) {
-            validate()
-            setShouldCheck(false)
-        }
-    }, [ shouldCheck ])
+    const getUser = async () => {
+        await validate()
+
+        return user
+    }
 
     return {
-        user,
-        token,
+        getUser,
         setToken,
-        checkAuth: () => setShouldCheck(true),
     }
 }

--- a/app/_hooks/auth/index.tsx
+++ b/app/_hooks/auth/index.tsx
@@ -6,9 +6,11 @@ import { useState, useEffect } from 'react'
 import { getCookie, setCookie, deleteCookie, hasCookie } from 'cookies-next'
 
 const useToken = () => {
-    const [ token, setToken ] = useState<string | null>(
-        hasCookie('algurado/token') ? getCookie('algurado/token')! : null
-    )
+    const data = hasCookie('algurado/token')
+        ? getCookie('algurado/token')!
+        : null
+
+    const [ token, setToken ] = useState<string | null>(data)
 
     useEffect(() => {
         if (token === null) {
@@ -22,11 +24,11 @@ const useToken = () => {
 }
 
 const useUser = () => {
-    const [ user, setUser ] = useState<User | null>(
-        hasCookie('algurado/user') 
+    const data = hasCookie('algurado/user') 
         ? JSON.parse(getCookie('algurado/user')!)
         : null
-    )
+
+    const [ user, setUser ] = useState<User | null>(data)
 
     useEffect(() => {
         if (user === null) {

--- a/app/_hooks/auth/index.tsx
+++ b/app/_hooks/auth/index.tsx
@@ -3,11 +3,12 @@
 import type { User } from '@models'
 
 import { useState, useEffect } from 'react'
-import { getCookie, setCookie, deleteCookie } from 'cookies-next'
+import { getCookie, setCookie, deleteCookie, hasCookie } from 'cookies-next'
 
 const useToken = () => {
-    const data = getCookie('algurado/token')
-    const [ token, setToken ] = useState<string | null>(data ?? null)
+    const [ token, setToken ] = useState<string | null>(
+        hasCookie('algurado/token') ? getCookie('algurado/token')! : null
+    )
 
     useEffect(() => {
         if (token === null) {
@@ -21,9 +22,10 @@ const useToken = () => {
 }
 
 const useUser = () => {
-    const data = getCookie('algurado/user')
     const [ user, setUser ] = useState<User | null>(
-        data ? JSON.parse(data) : null
+        hasCookie('algurado/user') 
+        ? JSON.parse(getCookie('algurado/user')!)
+        : null
     )
 
     useEffect(() => {

--- a/app/_hooks/auth/index.tsx
+++ b/app/_hooks/auth/index.tsx
@@ -2,35 +2,96 @@
 
 import type { User } from '@models'
 
-import { useState, useEffect } from 'react'
-import { cookies } from 'next/headers'
+import { useState, useEffect, useCallback } from 'react'
+import { getCookie, setCookie, deleteCookie } from 'cookies-next'
 
-export const useAuth = () => {
-    const [ user, setUser ] = useState<User | null>(null)
-    const [ loggedin, setLoggedin ] = useState<boolean>(false)
-
-    const storage = cookies()
-    const token = storage.get('algurado/token')?.value
+const useToken = () => {
+    const data = getCookie('algurado/token')
+    const [ token, setToken ] = useState<string | null>(data ?? null)
 
     useEffect(() => {
-        (async () => {
-            try {
-                const response = await fetch('api/v1/auth', {
-                    method: 'GET',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'Authorization': `Bearer ${token}`,
-                    },
-                })
-    
-                if (response.ok) {
-                    const data = await response.json()
-                    setUser(data.user!)
-                    setLoggedin(true)
-                }
-            } catch (error) {}
-        })()
-    }, [])
+        if (token === null) {
+            return deleteCookie('algurado/token')
+        }
 
-    return { user, setUser, loggedin, setLoggedin }
+        setCookie('algurado/token', token)
+    }, [ token ])
+
+    return { token, setToken }
+}
+
+const useUser = () => {
+    const data = getCookie('algurado/user')
+    const [ user, setUser ] = useState<User | null>(
+        data ? JSON.parse(data) : null
+    )
+
+    useEffect(() => {
+        if (user === null) {
+            return deleteCookie('algurado/user')
+        }
+
+        setCookie('algurado/user', user)
+    }, [ user ])
+
+    return { user, setUser }
+}
+
+const validate = async () => {
+    const { setUser } = useUser()
+    const { token, setToken } = useToken()
+
+    try {
+        const response = await fetch('api/v1/auth', {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${token}`,
+            },
+        })
+
+        if (response.ok) {
+            const data = await response.json()
+
+            setUser(data.user as User)
+            setToken(
+                response.headers.get('Authorization')?.split(' ')[1] ?? null
+            )
+
+            return
+        }
+    } catch (error) {}
+
+    setUser(null)
+    setToken(null)
+
+    return
+}
+
+const useValidate = useCallback(async () => {
+    await validate()
+}, [ validate ])
+
+export const useAuth = () => {
+    const { user } = useUser()
+    const { token, setToken } = useToken()
+    const [ shouldCheck, setShouldCheck ] = useState<boolean>(false)
+
+    useEffect(() => {
+        useValidate()
+    }, [ token ])
+
+    useEffect(() => {
+        if (shouldCheck) {
+            useValidate()
+            setShouldCheck(false)
+        }
+    }, [ shouldCheck ])
+
+    return {
+        user,
+        token,
+        setToken,
+        checkAuth: () => setShouldCheck(true),
+    }
 }

--- a/app/_hooks/auth/index.tsx
+++ b/app/_hooks/auth/index.tsx
@@ -69,5 +69,5 @@ export const useValidate = async () => {
 
         setUser(newUser)
         setToken(newToken)
-    }, [ token ])
+    }, [ setUser, setToken ])
 }

--- a/app/_hooks/auth/index.tsx
+++ b/app/_hooks/auth/index.tsx
@@ -2,7 +2,7 @@
 
 import type { User } from '@models'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect } from 'react'
 import { getCookie, setCookie, deleteCookie } from 'cookies-next'
 
 const useToken = () => {
@@ -68,22 +68,18 @@ const validate = async () => {
     return
 }
 
-const useValidate = useCallback(async () => {
-    await validate()
-}, [ validate ])
-
 export const useAuth = () => {
     const { user } = useUser()
     const { token, setToken } = useToken()
     const [ shouldCheck, setShouldCheck ] = useState<boolean>(false)
 
     useEffect(() => {
-        useValidate()
+        validate()
     }, [ token ])
 
     useEffect(() => {
         if (shouldCheck) {
-            useValidate()
+            validate()
             setShouldCheck(false)
         }
     }, [ shouldCheck ])

--- a/app/_hooks/auth/index.tsx
+++ b/app/_hooks/auth/index.tsx
@@ -2,15 +2,13 @@
 
 import type { User } from '@models'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, use } from 'react'
 import { getCookie, setCookie, deleteCookie, hasCookie } from 'cookies-next'
 
-const useToken = () => {
-    const data = hasCookie('algurado/token')
-        ? getCookie('algurado/token')!
-        : null
-
-    const [ token, setToken ] = useState<string | null>(data)
+export const useToken = () => {
+    const [ token, setToken ] = useState<string | null>(
+        hasCookie('algurado/token') ? getCookie('algurado/token')! : null
+    )
 
     useEffect(() => {
         if (token === null) {
@@ -23,12 +21,12 @@ const useToken = () => {
     return { token, setToken }
 }
 
-const useUser = () => {
-    const data = hasCookie('algurado/user') 
+export const useUser = () => {
+    const [ user, setUser ] = useState<User | null>(
+        hasCookie('algurado/user') 
         ? JSON.parse(getCookie('algurado/user')!)
         : null
-
-    const [ user, setUser ] = useState<User | null>(data)
+    )
 
     useEffect(() => {
         if (user === null) {
@@ -41,7 +39,7 @@ const useUser = () => {
     return { user, setUser }
 }
 
-const validate = async () => {
+export const useValidate = async () => {
     const { setUser } = useUser()
     const { token, setToken } = useToken()
 
@@ -70,19 +68,4 @@ const validate = async () => {
     setToken(null)
 
     return
-}
-
-export const useAuth = () => {
-    const { user } = useUser()
-    const { token, setToken } = useToken()
-
-    useEffect(() => {
-        validate()
-    }, [ token ])
-
-    return {
-        user,
-        validate,
-        setToken,
-    }
 }

--- a/app/api/v1/auth/login/route.ts
+++ b/app/api/v1/auth/login/route.ts
@@ -17,7 +17,7 @@ export async function POST (request: NextRequest) {
         const user: User = await knex('users').where({ username }).first()
 
         if (user && compareSync(password, user.hashed_password)) {
-            return NextResponse.json({}, {
+            return NextResponse.json({ user }, {
                 status: 200,
                 headers: {
                     'Content-Type': 'application/json',

--- a/app/api/v1/auth/route.ts
+++ b/app/api/v1/auth/route.ts
@@ -23,12 +23,13 @@ export async function GET (request: NextRequest) {
 
     try {
         const decoded = jwt.verify(token, process.env.JWT_SECRET!) as payload
+        const payload = { user: decoded.user }
 
-        return NextResponse.json({ user: decoded.user }, { 
+        return NextResponse.json(payload, { 
             status: 200,
             headers: {
                 'Content-Type': 'application/json',
-                'Authorization': `Bearer ${tokenize(decoded)}`
+                'Authorization': `Bearer ${tokenize(payload)}`
             },
         })
     } catch (error) {}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,12 +1,16 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 
-export const middleware = () => {
-    const headers = new Headers()
+export const middleware = (request: NextRequest) => {
+    const headers = new Headers(request.headers)
 
     headers.set('Content-Type', 'application/json')
     headers.set(
         'Access-Control-Allow-Origin',
-        'https://hurado.ncisomendoza.com',
+        `
+            https://hurado.ncisomendoza.com,
+            https://dev.hurado.ncisomendoza.com,
+            localhost:10000
+        `.trim().replace(/\s+/g, ' ')
     )
 
     return NextResponse.next({

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@types/bcryptjs": "^2.4.6",
         "axios": "^1.6.8",
         "bcryptjs": "^2.4.3",
+        "cookies-next": "^4.1.1",
         "dotenv": "^16.4.5",
         "jsonwebtoken": "^9.0.2",
         "knex": "^3.1.0",
@@ -684,6 +685,11 @@
       "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
       "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ=="
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
+    },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.6.tgz",
@@ -880,6 +886,29 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookies-next": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/cookies-next/-/cookies-next-4.1.1.tgz",
+      "integrity": "sha512-20QaN0iQSz87Os0BhNg9M71eM++gylT3N5szTlhq2rK6QvXn1FYGPB4eAgU4qFTunbQKhD35zfQ95ZWgzUy3Cg==",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "@types/node": "^16.10.2",
+        "cookie": "^0.6.0"
+      }
+    },
+    "node_modules/cookies-next/node_modules/@types/node": {
+      "version": "16.18.91",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.91.tgz",
+      "integrity": "sha512-h8Q4klc8xzc9kJKr7UYNtJde5TU2qEePVyH3WyzJaUC+3ptyc5kPQbWOIUcn8ZsG5+KSkq+P0py0kC0VqxgAXw=="
     },
     "node_modules/create-require": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/bcryptjs": "^2.4.6",
     "axios": "^1.6.8",
     "bcryptjs": "^2.4.3",
+    "cookies-next": "^4.1.1",
     "dotenv": "^16.4.5",
     "jsonwebtoken": "^9.0.2",
     "knex": "^3.1.0",


### PR DESCRIPTION
# Use appropriate cookies library for client-side renders

Just as the title says 😁

After finding out that the `cookies` function in `next/headers` only accommodates the SSR, I ended up finding out that we needed to install [`cookies-next`](https://www.npmjs.com/package/cookies-next).

To tell the truth, I had lots of fun modifying the authentication hooks! 😊

## Proposed changes

- Use [`cookies-next`](https://www.npmjs.com/package/cookies-next)
- Modify the authentication hooks
