### PR TITLE
Add max_points column to tasks table

### DIFF
--- a/knex/@types/task.ts
+++ b/knex/@types/task.ts
@@ -3,4 +3,5 @@ export type Task = {
     title: string
     description?: string
     statement: string
+    max_points: number
 }

--- a/knex/migrations/20240403142844_add_max_points_to_task_table.ts
+++ b/knex/migrations/20240403142844_add_max_points_to_task_table.ts
@@ -1,0 +1,16 @@
+import type { Knex } from "knex";
+
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.schema.alterTable('tasks', function (table) {
+        table.decimal('max_points', 5, 5)
+            .notNullable()
+    });
+}
+
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.schema.alterTable('tasks', function (table) {
+        table.dropColumn('max_points')
+    });
+}


### PR DESCRIPTION
# Add max_points column to tasks

This PR adds a migration to add the maximum attainable amount of points to a task.

## SQL Queries (via Knex debug)

```json
[
  {
    sql: 'alter table "tasks" add column "max_points" decimal(5, 5) not null',
    bindings: []
  }
]
```