### PR TITLE
Install Prettier for autoformatting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,29 +1,46 @@
 module.exports = {
-  parser: '@typescript-eslint/parser',
+  parser: "@typescript-eslint/parser",
   parserOptions: {
-    project: './tsconfig.json',
+    project: "./tsconfig.json",
     tsconfigRootDir: __dirname,
   },
-  extends: [
-    'eslint:recommended',
-    'next/core-web-vitals',
-    'airbnb',
-    'airbnb/hooks',
-  ],
+  extends: ["eslint:recommended", "next/core-web-vitals", "prettier"],
   rules: {
-    'no-console': ['warn', {
-      allow: ['info', 'warn', 'error'],
-    }],
-    'no-empty': 'off',
-    'consistent-return': 'off',
-    'import/extensions': ['error', 'never'],
-    'import/prefer-default-export': 'off',
-    'jsx-a11y/label-has-associated-control': 'off',
-    'react/function-component-definition': 'off',
-    'react/jsx-filename-extension': ['error', {
-      extensions: ['.jsx', '.tsx'],
-      ignoreFilesWithoutCode: true,
-    }],
-    'react/react-in-jsx-scope': 'off',
+    "no-console": [
+      "warn",
+      {
+        allow: ["info", "warn", "error"],
+      },
+    ],
+    "no-empty": "off",
+    "consistent-return": "off",
+    "import/extensions": ["error", "never"],
+    "import/no-unresolved": "off", // Let the typescript compiler handle module resolution
+    "import/order": [
+      "warn",
+      {
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          "parent",
+          "sibling",
+          "index",
+          "object",
+        ],
+        "alphabetize": { "caseInsensitive": false },
+      },
+    ],
+    "import/prefer-default-export": "off",
+    "jsx-a11y/label-has-associated-control": "off",
+    "react/function-component-definition": "off",
+    "react/jsx-filename-extension": [
+      "error",
+      {
+        extensions: [".jsx", ".tsx"],
+        ignoreFilesWithoutCode: true,
+      },
+    ],
+    "react/react-in-jsx-scope": "off",
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,8 @@
         "eslint": "8.57.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-next": "14.1.4",
+        "eslint-config-prettier": "^9.1.0",
+        "prettier": "^3.2.5",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.2"
       }
@@ -2169,6 +2171,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -4369,6 +4383,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "eslint": "8.57.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-next": "14.1.4",
+    "eslint-config-prettier": "^9.1.0",
+    "prettier": "^3.2.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.2"
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "knex:up": "knex --knexfile knex/knexfile.ts migrate:up",
     "knex:down": "knex --knexfile knex/knexfile.ts migrate:down",
     "knex:rollback": "knex --knexfile knex/knexfile.ts migrate:rollback",
-    "lint": "next lint"
+    "lint": "next lint",
+    "lint:fix": "next lint --fix && prettier src --write",
+    "format": "prettier src --write"
   },
   "repository": {
     "type": "git",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,260 @@
+module.exports = {
+  /**
+   * Print Width
+   * https://prettier.io/docs/en/options.html#print-width
+   *
+   * Specify the line length that the printer will wrap on.
+   *
+   * printWidth: <int>
+   * default: 80
+   */
+  printWidth: 80,
+
+  /**
+   * Tab Width
+   * https://prettier.io/docs/en/options.html#tab-width
+   *
+   * Specify the number of spaces per indentation-level.
+   *
+   * tabWidth: <int>
+   * default: 2
+   */
+  tabWidth: 2,
+
+  /**
+   * Tabs
+   * https://prettier.io/docs/en/options.html#tabs
+   *
+   * Indent lines with tabs instead of spaces.
+   *
+   * useTabs: <bool>
+   * default: false
+   */
+  // useTabs: false,
+
+  /**
+   * Semicolons
+   * https://prettier.io/docs/en/options.html#semicolons
+   *
+   * Print semicolons at the ends of statements
+   *
+   * semi: <bool>
+   * default: true
+   */
+  semi: true,
+
+  /**
+   * Quotes
+   * https://prettier.io/docs/en/options.html#quotes
+   *
+   * Use single quotes instead of double quotes.
+   *
+   * singleQuote: <bool>
+   * default: false
+   */
+  singleQuote: false,
+
+  /**
+   * Quote Props
+   * https://prettier.io/docs/en/options.html#quote-props
+   *
+   * Change when properties in objects are quoted.
+   *
+   * quoteProps: "<as-needed|consistent|preserve>"
+   * default: "as-needed"
+   */
+  quoteProps: "preserve",
+
+  /**
+   * JSX Quotes
+   * https://prettier.io/docs/en/options.html#jsx-quotes
+   *
+   * Use single quotes instead of double quotes in JSX.
+   *
+   * jsxSingleQuote: <bool>
+   * default: false
+   */
+  jsxSingleQuote: false,
+
+  /**
+   * Trailing Commas
+   * https://prettier.io/docs/en/options.html#trailing-commas
+   *
+   * Print trailing commas wherever possible when multi-line. (A single-line array, for example, never gets trailing commas.)
+   *
+   * trailingComma: "<es5|none|all>"
+   * default: 'es5'
+   */
+  trailingComma: "es5",
+
+  /**
+   * Bracket Spacing
+   * https://prettier.io/docs/en/options.html#bracket-spacing
+   *
+   * Print spaces between brackets in object literals.
+   *
+   * bracketSpacing: <bool>
+   * default: true
+   */
+  bracketSpacing: true,
+
+  /**
+   * Bracket Line
+   * https://prettier.io/docs/en/options.html#bracket-line
+   *
+   * Put the > of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
+   *
+   * bracketSameLine: <bool>
+   * default: false
+   */
+  // bracketSameLine: false,
+
+  /**
+   * [Deprecated] JSX Brackets
+   * https://prettier.io/docs/en/options.html#jsx-brackets
+   *
+   * This option has been deprecated in v2.4.0, use --bracket-same-line instead
+   * Put the > of a multi-line JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
+   *
+   * jsxBracketSameLine: <bool>
+   * default: false
+   */
+  // jsxBracketSameLine: false,
+
+  /**
+   * Arrow Function Parentheses
+   * https://prettier.io/docs/en/options.html#arrow-function-parentheses
+   *
+   * Include parentheses around a sole arrow function parameter.
+   *
+   * arrowParens: "<always|avoid>"
+   * default: "always"
+   */
+  arrowParens: "always",
+
+  /**
+   * Range
+   * https://prettier.io/docs/en/options.html#range
+   *
+   * Format only a segment of a file.
+   *
+   * rangeStart: <int>
+   * default: 0
+   *
+   * rangeEnd: <int>
+   * default: Infinity
+   */
+  // rangeStart: 0,
+  // rangeEnd: Infinity,
+
+  /**
+   * Parser
+   * https://prettier.io/docs/en/options.html#parser
+   *
+   * Specify which parser to use.
+   *
+   * parser: "<string>" | require("./my-parser")
+   * no default
+   *
+   */
+  // parser: '',
+
+  /**
+   * File Path
+   * https://prettier.io/docs/en/options.html#file-path
+   *
+   * Specify the file name to use to infer which parser to use.
+   *
+   * filepath: "<string>"
+   * no default
+   */
+  // filepath: '',
+
+  /**
+   * Require pragma
+   * https://prettier.io/docs/en/options.html#require-pragma
+   *
+   * Prettier can restrict itself to only format files that contain a special comment, called a pragma, at the top of the file. This is very useful when gradually transitioning large, unformatted codebases to prettier.
+   *
+   * requirePragma: <bool>
+   * default: false
+   */
+  // requirePragma: false,
+
+  /**
+   * Insert Pragma
+   * https://prettier.io/docs/en/options.html#insert-pragma
+   *
+   * Prettier can insert a special @format marker at the top of files specifying that the file has been formatted with prettier. This works well when used in tandem with the --require-pragma option. If there is already a docblock at the top of the file then this option will add a newline to it with the @format marker.
+   *
+   * insertPragma: <bool>
+   * default: false
+   */
+  // insertPragma: false,
+
+  /**
+   * Prose Wrap
+   * https://prettier.io/docs/en/options.html#prose-wrap
+   *
+   * By default, Prettier will wrap markdown text as-is since some services use a linebreak-sensitive renderer, e.g. GitHub comment and BitBucket. In some cases you may want to rely on editor/viewer soft wrapping instead, so this option allows you to opt out with "never".
+   *
+   * proseWrap: "<always|never|preserve>"
+   * default: "preserve"
+   */
+  // proseWrap: 'preserve',
+
+  /**
+   * HTML Whitespace Sensitivity
+   * https://prettier.io/docs/en/options.html#html-whitespace-sensitivity
+   *
+   * Specify the global whitespace sensitivity for HTML files, see whitespace-sensitive formatting for more info.
+   *
+   * htmlWhitespaceSensitivity: "<css|strict|ignore>"
+   * default: "css"
+   */
+  // htmlWhitespaceSensitivity: 'css',
+
+  /**
+   * Vue files script and style tags indentation
+   * https://prettier.io/docs/en/options.html#vue-files-script-and-style-tags-indentation
+   *
+   * Whether or not to indent the code inside <script> and <style> tags in Vue files. Some people (like the creator of Vue) don’t indent to save an indentation level, but this might break code folding in your editor.
+   *
+   * vueIndentScriptAndStyle: <bool>
+   * default: false
+   */
+  // vueIndentScriptAndStyle: false,
+
+  /**
+   * End of Line
+   * https://prettier.io/docs/en/options.html#end-of-line
+   *
+   * For historical reasons, there exist two common flavors of line endings in text files. That is \n (or LF for Line Feed) and \r\n (or CRLF for Carriage Return + Line Feed). The former is common on Linux and macOS, while the latter is prevalent on Windows. Some details explaining why it is so can be found on Wikipedia.
+   *
+   * endOfLine: "<lf|crlf|cr|auto>"
+   * default: "lf"
+   */
+  // endOfLine: 'lf',
+
+  /**
+   * Embedded Language Formatting
+   * https://prettier.io/docs/en/options.html#embedded-language-formatting
+   *
+   * Control whether Prettier formats quoted code embedded in the file.
+   *
+   * embeddedLanguageFormatting: "<off|auto>"
+   * default: "auto"
+   */
+  // embeddedLanguageFormatting: 'auto',
+
+  /**
+   * Single Attribute Per Line
+   * https://prettier.io/docs/en/options.html#single-attribute-per-line
+   *
+   * Enforce single attribute per line in HTML, Vue and JSX.
+   *
+   * singleAttributePerLine: "<bool>"
+   * default: "false"
+   */
+  // singleAttributePerLine: 'false',
+};

--- a/src/app/(auth)/login/page.module.css
+++ b/src/app/(auth)/login/page.module.css
@@ -1,55 +1,57 @@
 #loginform {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
 
-    width: 80%;
-    max-width: 500px;
-    height: fit-content;
-    gap: 20px;
-    padding: 15px 40px;
+  width: 80%;
+  max-width: 500px;
+  height: fit-content;
+  gap: 20px;
+  padding: 15px 40px;
 
-    border: 1px solid black;
-    border-radius: 20px;
+  border: 1px solid black;
+  border-radius: 20px;
 }
 
 #loginform h1 {
-    font-size: xx-large;
+  font-size: xx-large;
 }
 
 #loginform button {
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
-    width: 100%;
-    height: fit-content;
-    padding: 10px;
+  width: 100%;
+  height: fit-content;
+  padding: 10px;
 
-    border: 1px solid black;
-    border-radius: 20px;
+  border: 1px solid black;
+  border-radius: 20px;
 
-    background-color: var(--purple);
+  background-color: var(--purple);
 }
 
 #loginform input {
-    width: 100%;
-    max-width: 300px;
-    border-bottom: 1px solid grey;
+  width: 100%;
+  max-width: 300px;
+  border-bottom: 1px solid grey;
 }
 
 .row {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
 
-    width: 100%;
-    height: fit-content;
-    gap: 10px;
+  width: 100%;
+  height: fit-content;
+  gap: 10px;
 }
 
 @media (max-width: 540px) {
-    #loginform { width: 95%; }
+  #loginform {
+    width: 95%;
+  }
 }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,14 +1,12 @@
-'use client';
+"use client";
 
-import type { FunctionComponent } from 'react';
+import type { FunctionComponent } from "react";
 
-import { useRouter } from 'next/navigation';
-import {
-  useEffect, useState, useRef, useCallback,
-} from 'react';
+import { useRouter } from "next/navigation";
+import { useEffect, useState, useRef, useCallback } from "react";
 
-import { useToken, useUser } from 'lib/hooks';
-import styles from './page.module.css';
+import { useToken, useUser } from "lib/hooks";
+import styles from "./page.module.css";
 
 const Page: FunctionComponent = () => {
   const [throttle, setThrottle] = useState<boolean>(false);
@@ -16,25 +14,25 @@ const Page: FunctionComponent = () => {
   const submit = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-        submit.current!.style.backgroundColor = throttle
-          ? 'var(--purple-light)'
-          : 'var(--purple)';
+    submit.current!.style.backgroundColor = throttle
+      ? "var(--purple-light)"
+      : "var(--purple)";
   }, [throttle]);
 
   const router = useRouter();
 
-  const [username, setUsername] = useState<string>('');
-  const [password, setPassword] = useState<string>('');
+  const [username, setUsername] = useState<string>("");
+  const [password, setPassword] = useState<string>("");
 
   const { setUser } = useUser();
   const { setToken } = useToken();
 
   const login = useCallback(async () => {
     try {
-      const response = await fetch('api/v1/auth/login', {
-        method: 'POST',
+      const response = await fetch("api/v1/auth/login", {
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
         body: JSON.stringify({
           username,
@@ -43,12 +41,12 @@ const Page: FunctionComponent = () => {
       });
 
       if (!response.ok) {
-        throw new Error('');
+        throw new Error("");
       }
 
-      setToken(response.headers.get('Authorization')!.split(' ')[1]);
+      setToken(response.headers.get("Authorization")!.split(" ")[1]);
       setUser(await response.json());
-      router.push('/dashboard');
+      router.push("/dashboard");
     } catch (error) {}
   }, [router, username, password, setToken, setUser]);
 

--- a/src/app/(auth)/register/page.module.css
+++ b/src/app/(auth)/register/page.module.css
@@ -1,55 +1,57 @@
 #registerform {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
 
-    width: 80%;
-    max-width: 550px;
-    height: fit-content;
-    gap: 20px;
-    padding: 15px 40px;
+  width: 80%;
+  max-width: 550px;
+  height: fit-content;
+  gap: 20px;
+  padding: 15px 40px;
 
-    border: 1px solid black;
-    border-radius: 20px;
+  border: 1px solid black;
+  border-radius: 20px;
 }
 
 #registerform h1 {
-    font-size: xx-large;
+  font-size: xx-large;
 }
 
 #registerform button {
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
-    width: 100%;
-    height: fit-content;
-    padding: 10px;
+  width: 100%;
+  height: fit-content;
+  padding: 10px;
 
-    border: 1px solid black;
-    border-radius: 20px;
+  border: 1px solid black;
+  border-radius: 20px;
 
-    background-color: var(--purple);
+  background-color: var(--purple);
 }
 
 #registerform input {
-    width: 100%;
-    max-width: 300px;
-    border-bottom: 1px solid grey;
+  width: 100%;
+  max-width: 300px;
+  border-bottom: 1px solid grey;
 }
 
 .row {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
 
-    width: 100%;
-    height: fit-content;
-    gap: 10px;
+  width: 100%;
+  height: fit-content;
+  gap: 10px;
 }
 
 @media (max-width: 540px) {
-    #registerform { width: 95%; }
+  #registerform {
+    width: 95%;
+  }
 }

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,13 +1,11 @@
-'use client';
+"use client";
 
-import type { FunctionComponent } from 'react';
+import type { FunctionComponent } from "react";
 
-import { useRouter } from 'next/navigation';
-import {
-  useEffect, useState, useRef, useCallback,
-} from 'react';
+import { useRouter } from "next/navigation";
+import { useEffect, useState, useRef, useCallback } from "react";
 
-import styles from './page.module.css';
+import styles from "./page.module.css";
 
 const Page: FunctionComponent = () => {
   const [throttle, setThrottle] = useState<boolean>(false);
@@ -15,24 +13,24 @@ const Page: FunctionComponent = () => {
   const submit = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-        submit.current!.style.backgroundColor = throttle
-          ? 'var(--purple-light)'
-          : 'var(--purple)';
+    submit.current!.style.backgroundColor = throttle
+      ? "var(--purple-light)"
+      : "var(--purple)";
   }, [throttle]);
 
   const router = useRouter();
 
-  const [email, setEmail] = useState<string>('');
-  const [username, setUsername] = useState<string>('');
-  const [password, setPassword] = useState<string>('');
-  const [confirmPassword, setConfirmPassword] = useState<string>('');
+  const [email, setEmail] = useState<string>("");
+  const [username, setUsername] = useState<string>("");
+  const [password, setPassword] = useState<string>("");
+  const [confirmPassword, setConfirmPassword] = useState<string>("");
 
   const register = useCallback(async () => {
     try {
-      const response = await fetch('api/v1/auth/register', {
-        method: 'POST',
+      const response = await fetch("api/v1/auth/register", {
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
         body: JSON.stringify({
           email,
@@ -43,10 +41,10 @@ const Page: FunctionComponent = () => {
       });
 
       if (!response.ok) {
-        throw new Error('');
+        throw new Error("");
       }
 
-      router.push('/login');
+      router.push("/login");
     } catch (error) {}
 
     setThrottle(false);

--- a/src/app/api/v1/auth/login/route.ts
+++ b/src/app/api/v1/auth/login/route.ts
@@ -1,27 +1,27 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { compareSync } from 'bcryptjs';
+import { NextRequest, NextResponse } from "next/server";
+import { compareSync } from "bcryptjs";
 
-import knex from 'db';
-import { User } from 'lib/models';
+import knex from "db";
+import { User } from "lib/models";
 
-import { tokenize } from '../route';
+import { tokenize } from "../route";
 
 export async function POST(request: NextRequest) {
-  const {
-    username,
-    password,
-  } = await request.json();
+  const { username, password } = await request.json();
 
-  const user: User = await knex('users').where({ username }).first();
+  const user: User = await knex("users").where({ username }).first();
 
   if (user && compareSync(password, user.hashed_password)) {
-    return NextResponse.json({ user }, {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${tokenize({ user })}`,
-      },
-    });
+    return NextResponse.json(
+      { user },
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${tokenize({ user })}`,
+        },
+      }
+    );
   }
 
   return NextResponse.json({}, { status: 401 });

--- a/src/app/api/v1/auth/register/route.ts
+++ b/src/app/api/v1/auth/register/route.ts
@@ -1,20 +1,14 @@
-import type { User } from 'lib/models';
+import { NextRequest, NextResponse } from "next/server";
+import { hashSync } from "bcryptjs";
+import type { User } from "lib/models";
 
-import { NextRequest, NextResponse } from 'next/server';
-import { hashSync } from 'bcryptjs';
-
-import knex from 'db';
+import knex from "db";
 
 export async function POST(request: NextRequest) {
-  const {
-    email,
-    username,
-    password,
-    confirmPassword,
-  } = await request.json();
+  const { email, username, password, confirmPassword } = await request.json();
 
   try {
-    const user: User = await knex('users').where({ email }).first();
+    const user: User = await knex("users").where({ email }).first();
 
     if (user) {
       return NextResponse.json({}, { status: 409 });
@@ -22,7 +16,7 @@ export async function POST(request: NextRequest) {
   } catch (error) {}
 
   try {
-    const user: User = await knex('users').where({ username }).first();
+    const user: User = await knex("users").where({ username }).first();
 
     if (user) {
       return NextResponse.json({}, { status: 409 });
@@ -33,7 +27,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({}, { status: 400 });
   }
 
-  await knex('users').insert({
+  await knex("users").insert({
     email,
     username,
     hashed_password: hashSync(password, 10),

--- a/src/app/api/v1/auth/route.ts
+++ b/src/app/api/v1/auth/route.ts
@@ -1,19 +1,19 @@
-import type { User } from 'lib/models';
+import jwt from "jsonwebtoken";
 
-import jwt from 'jsonwebtoken';
-
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from "next/server";
+import type { User } from "lib/models";
 
 type ServerPayload = {
-    user: User
-}
+  user: User;
+};
 
-export const tokenize = (load: ServerPayload) => jwt.sign(load, process.env.JWT_SECRET!, {
-  expiresIn: process.env.JWT_EXPIRE!,
-});
+export const tokenize = (load: ServerPayload) =>
+  jwt.sign(load, process.env.JWT_SECRET!, {
+    expiresIn: process.env.JWT_EXPIRE!,
+  });
 
 export async function GET(request: NextRequest) {
-  const token = request.headers.get('Authorization')?.split(' ')[1];
+  const token = request.headers.get("Authorization")?.split(" ")[1];
 
   if (!token) {
     return NextResponse.json({}, { status: 401 });
@@ -26,7 +26,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(payload, {
       status: 200,
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
         Authorization: `Bearer ${tokenize(payload)}`,
       },
     });

--- a/src/app/api/v1/tasks/[...slug]/route.ts
+++ b/src/app/api/v1/tasks/[...slug]/route.ts
@@ -1,13 +1,13 @@
-import { NextResponse, NextRequest } from 'next/server';
+import { NextResponse, NextRequest } from "next/server";
 
-import knex from 'db';
+import knex from "db";
 
 export async function GET(request: NextRequest) {
   const url = new URL(request.nextUrl);
-  const slug = url.pathname.split('/').pop();
+  const slug = url.pathname.split("/").pop();
 
   try {
-    const task = await knex('tasks').where({ slug }).first();
+    const task = await knex("tasks").where({ slug }).first();
 
     if (task) {
       return NextResponse.json(task, { status: 200 });

--- a/src/app/api/v1/tasks/route.ts
+++ b/src/app/api/v1/tasks/route.ts
@@ -1,12 +1,11 @@
-import type { Task } from 'lib/models';
+import { NextResponse } from "next/server";
+import type { Task } from "lib/models";
 
-import { NextResponse } from 'next/server';
-
-import knex from 'db';
+import knex from "db";
 
 export async function GET() {
   try {
-    const tasks: Task[] = await knex('tasks').select();
+    const tasks: Task[] = await knex("tasks").select();
 
     return NextResponse.json(tasks, { status: 200 });
   } catch (error) {}

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -1,45 +1,46 @@
 :root {
-    --purple: rgb(109, 117, 254);
-    --purple-light: rgb(197, 195, 255);
-    --purple-white: rgb(237, 235, 255);
+  --purple: rgb(109, 117, 254);
+  --purple-light: rgb(197, 195, 255);
+  --purple-white: rgb(237, 235, 255);
 
-    --yellow: rgb(234, 233, 126);
-    --yellow-light: rgb(243, 243, 215);
+  --yellow: rgb(234, 233, 126);
+  --yellow-light: rgb(243, 243, 215);
 
-    --darken: rgb(0, 0, 0, 0.10);
-    --lighten: rgb(255, 255, 255, 0.10);
+  --darken: rgb(0, 0, 0, 0.1);
+  --lighten: rgb(255, 255, 255, 0.1);
 }
 
-a:hover, button:hover {
-    cursor: pointer;
+a:hover,
+button:hover {
+  cursor: pointer;
 }
 
 body {
-    display: flex;
-    flex-direction: column;
-    
-    width: 100%;
-    height: fit-content;
+  display: flex;
+  flex-direction: column;
+
+  width: 100%;
+  height: fit-content;
 }
 
 main {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    
-    width: 100%;
-    height: fit-content;
-    gap: 15px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  height: fit-content;
+  gap: 15px;
 }
 
 footer {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 
-    width: 100%;
-    height: fit-content;
-    padding: 5px 20px;
+  width: 100%;
+  height: fit-content;
+  padding: 5px 20px;
 }

--- a/src/app/layout.module.css
+++ b/src/app/layout.module.css
@@ -1,23 +1,25 @@
 #navbar {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
 
-    width: 100%;
-    height: fit-content;
-    padding: 5px 40px;
+  width: 100%;
+  height: fit-content;
+  padding: 5px 40px;
 }
 
 .copyright {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    
-    width: 100%;
-    height: fit-content;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  height: fit-content;
 }
 
 @media (max-width: 540px) {
-    #navbar { padding: 5px 20px; }
+  #navbar {
+    padding: 5px 20px;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,29 +1,29 @@
-import '@root/reset.css';
-import '@root/global.css';
+import "@root/reset.css";
+import "@root/global.css";
 
-import type { FunctionComponent, ReactNode } from 'react';
-import type { Metadata } from 'next';
+import type { FunctionComponent, ReactNode } from "react";
+import type { Metadata } from "next";
 
 // eslint-disable-next-line camelcase
-import { Work_Sans } from 'next/font/google';
+import { Work_Sans } from "next/font/google";
 
-import { Navbar } from 'lib/components';
-import styles from './layout.module.css';
+import { Navbar } from "lib/components";
+import styles from "./layout.module.css";
 
 export const metadata: Metadata = {
   title: {
-    template: '%s | Algurado',
-    default: 'Algurado',
+    template: "%s | Algurado",
+    default: "Algurado",
   },
-  description: 'NOI.PH\'s online judge.',
+  description: "NOI.PH's online judge.",
 };
 
-type props = { children: ReactNode }
+type props = { children: ReactNode };
 
 const worksans = Work_Sans({
-  weight: 'variable',
-  style: ['normal', 'italic'],
-  subsets: ['latin'],
+  weight: "variable",
+  style: ["normal", "italic"],
+  subsets: ["latin"],
 });
 
 const RootLayout: FunctionComponent<props> = ({ children }) => (
@@ -32,7 +32,7 @@ const RootLayout: FunctionComponent<props> = ({ children }) => (
       <header id={styles.navbar}>
         <Navbar />
       </header>
-      <main>{ children }</main>
+      <main>{children}</main>
       <footer>
         <p className={styles.copyright}>© 2024 NOI.PH</p>
       </footer>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,11 @@
-import type { FunctionComponent } from 'react';
+import type { FunctionComponent } from "react";
 
-const Page: FunctionComponent = () => (
-  <p>Hello, world!</p>
-);
+const Page: FunctionComponent = () => {
+  return (
+    <p>
+      <div>Hello, world!</div>
+    </p>
+  );
+};
 
 export default Page;

--- a/src/app/reset.css
+++ b/src/app/reset.css
@@ -1,86 +1,93 @@
-*:where(:not(html, iframe, canvas, img, svg, video, audio):not(svg *, symbol *)) {
-    all: unset;
-    display: revert;
+*:where(
+    :not(html, iframe, canvas, img, svg, video, audio):not(svg *, symbol *)
+  ) {
+  all: unset;
+  display: revert;
 }
 
 *,
 *::before,
 *::after {
-    box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 html {
-    -moz-text-size-adjust: none;
-    -webkit-text-size-adjust: none;
-    text-size-adjust: none;
+  -moz-text-size-adjust: none;
+  -webkit-text-size-adjust: none;
+  text-size-adjust: none;
 }
 
-a, button {
-    cursor: revert;
+a,
+button {
+  cursor: revert;
 }
 
-ol, ul, menu, summary {
-    list-style: none;
+ol,
+ul,
+menu,
+summary {
+  list-style: none;
 }
 
 img {
-    max-inline-size: 100%;
-    max-block-size: 100%;
+  max-inline-size: 100%;
+  max-block-size: 100%;
 }
 
 table {
-    border-collapse: collapse;
+  border-collapse: collapse;
 }
 
-input, textarea {
-    -webkit-user-select: auto;
-    user-select: auto;
+input,
+textarea {
+  -webkit-user-select: auto;
+  user-select: auto;
 }
 
 textarea {
-    white-space: revert;
+  white-space: revert;
 }
 
 meter {
-    -webkit-appearance: revert;
-    appearance: revert;
+  -webkit-appearance: revert;
+  appearance: revert;
 }
 
 :where(pre) {
-    all: revert;
-    box-sizing: border-box;
+  all: revert;
+  box-sizing: border-box;
 }
 
 ::placeholder {
-    color: unset;
+  color: unset;
 }
 
 :where([hidden]) {
-    display: none;
+  display: none;
 }
 
 :where([contenteditable]:not([contenteditable="false"])) {
-    -moz-user-modify: read-write;
-    -webkit-user-modify: read-write;
-    
-    overflow-wrap: break-word;
+  -moz-user-modify: read-write;
+  -webkit-user-modify: read-write;
 
-    -webkit-line-break: after-white-space;
-    line-break: after-white-space;
+  overflow-wrap: break-word;
 
-    -webkit-user-select: auto;
-    user-select: auto;
+  -webkit-line-break: after-white-space;
+  line-break: after-white-space;
+
+  -webkit-user-select: auto;
+  user-select: auto;
 }
 
 :where([draggable="true"]) {
-    -webkit-user-drag: element;
+  -webkit-user-drag: element;
 }
 
 :where(dialog:modal) {
-    all: revert;
-    box-sizing: border-box;
+  all: revert;
+  box-sizing: border-box;
 }
 
 ::-webkit-details-marker {
-    display: none;
+  display: none;
 }

--- a/src/app/tasks/[...slug]/page.tsx
+++ b/src/app/tasks/[...slug]/page.tsx
@@ -1,9 +1,7 @@
-import type { Task } from 'lib/models';
-
-import { Fragment } from 'react';
+import type { Task } from "lib/models";
 
 export async function generateStaticParams() {
-  const response = await fetch('/api/v1/tasks');
+  const response = await fetch("/api/v1/tasks");
   const tasks = await response.json();
 
   return tasks.map((task: Task) => ({
@@ -12,21 +10,19 @@ export async function generateStaticParams() {
 }
 
 type props = {
-    params: {
-        slug: string
-    }
-}
+  params: {
+    slug: string;
+  };
+};
 
 async function generateStaticProps(slug: string) {
   // generateStaticProps does not resolve the server URL
-  const response = await fetch(
-    `${process.env.SERVER!}/api/v1/tasks/${slug}`,
-  );
+  const response = await fetch(`${process.env.SERVER!}/api/v1/tasks/${slug}`);
   const task = await response.json();
 
   return {
     title: task.title,
-    description: task.description ?? '',
+    description: task.description ?? "",
     statement: task.statement,
   };
 }
@@ -36,9 +32,9 @@ async function Page({ params: { slug } }: props) {
 
   return (
     <>
-      <h1>{ title }</h1>
-      <p>{ description }</p>
-      <p>{ statement }</p>
+      <h1>{title}</h1>
+      <p>{description}</p>
+      <p>{statement}</p>
     </>
   );
 }

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -1,20 +1,15 @@
-'use client';
+"use client";
 
-import {
-  useEffect,
-  useState,
-  FunctionComponent,
-  ReactNode,
-} from 'react';
-import type { Task } from 'lib/models';
-import { TaskCard } from 'lib/components';
+import { useEffect, useState, FunctionComponent, ReactNode } from "react";
+import type { Task } from "lib/models";
+import { TaskCard } from "lib/components";
 
 const Page: FunctionComponent = () => {
   const [tasks, setTasks] = useState<Task[]>([]);
 
   useEffect(() => {
     (async () => {
-      const response = await fetch('/api/v1/tasks');
+      const response = await fetch("/api/v1/tasks");
 
       setTasks(await response.json());
     })();
@@ -23,12 +18,10 @@ const Page: FunctionComponent = () => {
   const [taskNodes, setTaskNodes] = useState<ReactNode[]>([]);
 
   useEffect(() => {
-    setTaskNodes(tasks.map((task) => <TaskCard task={task} />));
+    setTaskNodes(tasks.map((task) => <TaskCard key={task.slug} task={task} />));
   }, [tasks]);
 
-  return (
-    { ...taskNodes }
-  );
+  return { ...taskNodes };
 };
 
 export default Page;

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,6 @@
-import createKnex, { Knex } from 'knex';
+import createKnex, { Knex } from "knex";
 
-import config from './knexfile';
+import config from "./knexfile";
 
 const knex: Knex = createKnex(config.development);
 

--- a/src/db/knexfile.ts
+++ b/src/db/knexfile.ts
@@ -1,13 +1,13 @@
-import fs from 'fs';
-import dotenv from 'dotenv';
-import type { Knex } from 'knex';
+import fs from "fs";
+import dotenv from "dotenv";
+import type { Knex } from "knex";
 
 let currentPath = process.cwd();
 
 while (!fs.existsSync(`${currentPath}/.env`)) {
   currentPath = `${currentPath}/..`;
-  if (currentPath === '/') {
-    console.error('Could not find .env file');
+  if (currentPath === "/") {
+    console.error("Could not find .env file");
     process.exit(1);
   }
 }
@@ -16,20 +16,23 @@ const ENV_PATH = fs.realpathSync(`${currentPath}/.env`);
 console.info(`Loading environment from ${ENV_PATH}`);
 dotenv.config({ path: ENV_PATH });
 
-const POSTGRES_HOSTNAME = process.env.IS_UNDER_DOCKER === 'true'
-  ? process.env.DOCKER_POSTGRES_HOSTNAME
-  : process.env.POSTGRES_HOSTNAME;
+const POSTGRES_HOSTNAME =
+  process.env.IS_UNDER_DOCKER === "true"
+    ? process.env.DOCKER_POSTGRES_HOSTNAME
+    : process.env.POSTGRES_HOSTNAME;
 
 const defaults = {
-  client: 'pg',
+  client: "pg",
   connection: `
         postgresql://${process.env.POSTGRES_USER}
         :${process.env.POSTGRES_PASSWORD}
         @${POSTGRES_HOSTNAME}
         /${process.env.POSTGRES_DB}
-    `.replace(/\s+/g, '').trim(),
+    `
+    .replace(/\s+/g, "")
+    .trim(),
   migrations: {
-    tableName: 'knex_migrations',
+    tableName: "knex_migrations",
     directory: fs.realpathSync(`${currentPath}/src/db/migrations`),
   },
   seeds: {
@@ -45,7 +48,7 @@ const config: { [key: string]: Knex.Config } = {
     useNullAsDefault: true,
     pool: {
       afterCreate: (conn: any, done: any) => {
-        console.debug('Pool created');
+        console.debug("Pool created");
         done(false, conn);
       },
     },

--- a/src/db/migrations/20240320074557_add_uuid_functions.ts
+++ b/src/db/migrations/20240320074557_add_uuid_functions.ts
@@ -1,4 +1,4 @@
-import type { Knex } from 'knex';
+import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   return knex.schema.raw(`

--- a/src/db/migrations/20240320074757_initial_migration.ts
+++ b/src/db/migrations/20240320074757_initial_migration.ts
@@ -1,45 +1,28 @@
-import type { Knex } from 'knex';
+import type { Knex } from "knex";
 
 export async function up(knex: Knex): Promise<void> {
   return knex.schema
-    .createTable('users', (table) => {
-      table.uuid('id')
-        .primary()
-        .defaultTo(knex.raw('uuid_generate_v4()'));
-      table.text('email')
-        .notNullable()
-        .unique();
-      table.text('username')
-        .notNullable()
-        .unique();
-      table.text('hashed_password')
-        .notNullable();
-      table.timestamp('created_at')
-        .defaultTo(knex.fn.now());
+    .createTable("users", (table) => {
+      table.uuid("id").primary().defaultTo(knex.raw("uuid_generate_v4()"));
+      table.text("email").notNullable().unique();
+      table.text("username").notNullable().unique();
+      table.text("hashed_password").notNullable();
+      table.timestamp("created_at").defaultTo(knex.fn.now());
       // TODO: Implement user roles (e.g., admin, user, etc.)
-      table.text('school');
-      table.text('name');
+      table.text("school");
+      table.text("name");
       // TODO: Implement user country (default to PH)
     })
-    .createTable('tasks', (table) => {
-      table.uuid('id')
-        .primary()
-        .defaultTo(knex.raw('uuid_generate_v4()'));
-      table.text('slug')
-        .notNullable()
-        .unique();
-      table.text('title')
-        .notNullable();
-      table.text('description');
-      table.text('statement')
-        .notNullable();
-      table.decimal('max_points', 5, 5)
-        .notNullable();
+    .createTable("tasks", (table) => {
+      table.uuid("id").primary().defaultTo(knex.raw("uuid_generate_v4()"));
+      table.text("slug").notNullable().unique();
+      table.text("title").notNullable();
+      table.text("description");
+      table.text("statement").notNullable();
+      table.decimal("max_points", 5, 5).notNullable();
     });
 }
 
 export async function down(knex: Knex): Promise<void> {
-  return knex.schema
-    .dropTable('users')
-    .dropTable('tasks');
+  return knex.schema.dropTable("users").dropTable("tasks");
 }

--- a/src/db/seeds/create_dummy_tasks/20240310495057.ts
+++ b/src/db/seeds/create_dummy_tasks/20240310495057.ts
@@ -1,13 +1,15 @@
-import { Knex } from 'knex';
+import { Knex } from "knex";
 
 export async function seed(knex: Knex): Promise<void> {
-  await knex('tasks').insert([{
-    slug: 'who-is-the-oldest',
-    title: 'Who is the oldest?',
-    statement: [
-      'Alvin, Berto, and Carlo are friends. Their ages are $$A$$, $$B$$ and $$C$$, respectively. No two of them have the same age. Who is the oldest among them?',
-      'The input contains three lines. The first line contains a single integer, $$A$$. The second line contains a single integer, $$B$$. The third line contains a single integer, $$C$$.',
-      'Output the name of the oldest among the three, which should be either Alvin, Berto or Carlo.',
-    ].join('\n'),
-  }]);
+  await knex("tasks").insert([
+    {
+      slug: "who-is-the-oldest",
+      title: "Who is the oldest?",
+      statement: [
+        "Alvin, Berto, and Carlo are friends. Their ages are $$A$$, $$B$$ and $$C$$, respectively. No two of them have the same age. Who is the oldest among them?",
+        "The input contains three lines. The first line contains a single integer, $$A$$. The second line contains a single integer, $$B$$. The third line contains a single integer, $$C$$.",
+        "Output the name of the oldest among the three, which should be either Alvin, Berto or Carlo.",
+      ].join("\n"),
+    },
+  ]);
 }

--- a/src/db/seeds/create_dummy_users.ts
+++ b/src/db/seeds/create_dummy_users.ts
@@ -1,14 +1,16 @@
-import { Knex } from 'knex';
-import { hashSync } from 'bcryptjs';
+import { Knex } from "knex";
+import { hashSync } from "bcryptjs";
 
 const hash = (password: string) => hashSync(password, 10);
 
 export async function seed(knex: Knex): Promise<void> {
-  await knex('users').insert([{
-    email: 'user-4b018dd0-8316@mailinator.com',
-    username: 'user-4b018dd0-8316',
-    hashed_password: hash('password'),
-    school: 'University of the Philippines - Diliman',
-    name: 'User 4b018dd0-8316',
-  }]);
+  await knex("users").insert([
+    {
+      email: "user-4b018dd0-8316@mailinator.com",
+      username: "user-4b018dd0-8316",
+      hashed_password: hash("password"),
+      school: "University of the Philippines - Diliman",
+      name: "User 4b018dd0-8316",
+    },
+  ]);
 }

--- a/src/db/tsconfig.json
+++ b/src/db/tsconfig.json
@@ -1,11 +1,9 @@
 {
-    "transpileOnly": true,
-    "compilerOptions": {
-        "target": "ES6",
-        "module": "Node16",
-        "moduleResolution": "Node16"
-    },
-    "include": [
-        "**/*.ts"
-    ]
+  "transpileOnly": true,
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "Node16",
+    "moduleResolution": "Node16"
+  },
+  "include": ["**/*.ts"]
 }

--- a/src/lib/components/card/index.ts
+++ b/src/lib/components/card/index.ts
@@ -1,1 +1,1 @@
-export * from './task';
+export * from "./task";

--- a/src/lib/components/card/task/index.module.css
+++ b/src/lib/components/card/task/index.module.css
@@ -1,18 +1,22 @@
 .container {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
 
-    width: 95%;
-    max-width: 800px;
-    height: fit-content;
-    padding: 15px;
+  width: 95%;
+  max-width: 800px;
+  height: fit-content;
+  padding: 15px;
 
-    border: 1px solid black;
-    border-radius: 15px;
+  border: 1px solid black;
+  border-radius: 15px;
 }
 
-.container:hover { background-color: var(--darken); }
+.container:hover {
+  background-color: var(--darken);
+}
 
-.container > h2 { font-size: x-large; }
+.container > h2 {
+  font-size: x-large;
+}

--- a/src/lib/components/card/task/index.tsx
+++ b/src/lib/components/card/task/index.tsx
@@ -1,26 +1,19 @@
-import type { FunctionComponent } from 'react';
-import type { Task } from 'lib/models';
+import { FunctionComponent } from "react";
+import Link from "next/link";
+import { Task } from "lib/models";
+import styles from "./index.module.css";
 
-import Link from 'next/link';
+type TaskCardProps = {
+  task: Task;
+};
 
-import styles from './index.module.css';
-
-type props = {
-    task: Task
-}
-
-export const TaskCard: FunctionComponent<props> = ({ task }) => (
+export const TaskCard: FunctionComponent<TaskCardProps> = ({ task }) => (
   <Link
     key={task.slug}
     href={`/tasks/${task.slug}`}
     className={styles.container}
   >
-    <h2>{ task.title }</h2>
-    <p>
-      {
-            task.description
-            ?? 'No description was provided for this task.'
-        }
-    </p>
+    <h2>{task.title}</h2>
+    <p>{task.description ?? "No description was provided for this task."}</p>
   </Link>
 );

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -1,2 +1,2 @@
-export * from './navbar';
-export * from './card';
+export * from "./navbar";
+export * from "./card";

--- a/src/lib/components/navbar/guest.tsx
+++ b/src/lib/components/navbar/guest.tsx
@@ -1,8 +1,8 @@
-import type { FunctionComponent } from 'react';
+import type { FunctionComponent } from "react";
 
-import Link from 'next/link';
+import Link from "next/link";
 
-import styles from './index.module.css';
+import styles from "./index.module.css";
 
 export const Guest: FunctionComponent = () => (
   <div className={`${styles.row} ${styles.desktoplinks}`}>

--- a/src/lib/components/navbar/index.module.css
+++ b/src/lib/components/navbar/index.module.css
@@ -1,14 +1,16 @@
 .row {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
 
-    width: fit-content;
-    height: fit-content;
-    gap: 20px;
+  width: fit-content;
+  height: fit-content;
+  gap: 20px;
 }
 
 @media (max-width: 768px) {
-    .desktoplinks { display: none; }
+  .desktoplinks {
+    display: none;
+  }
 }

--- a/src/lib/components/navbar/index.tsx
+++ b/src/lib/components/navbar/index.tsx
@@ -1,32 +1,30 @@
-'use client';
+"use client";
 
-import type { FunctionComponent, ReactNode } from 'react';
+import type { FunctionComponent, ReactNode } from "react";
 
-import Link from 'next/link';
+import Link from "next/link";
 
-import { Fragment, useEffect, useState } from 'react';
+import { Fragment, useEffect, useState } from "react";
 
-import { useUser } from 'lib/hooks';
-import styles from './index.module.css';
+import { useUser } from "lib/hooks";
+import styles from "./index.module.css";
 
-import { Member } from './member';
-import { Guest } from './guest';
+import { Member } from "./member";
+import { Guest } from "./guest";
 
 export const Navbar: FunctionComponent = () => {
   const { user } = useUser();
   const [links, setLinks] = useState<ReactNode>(null);
 
   useEffect(() => {
-    setLinks(
-      user ? <Member /> : <Guest />,
-    );
+    setLinks(user ? <Member /> : <Guest />);
   }, [user]);
 
   return (
     <>
       <div className={styles.row}>
         <Link href="/">Home</Link>
-        { links }
+        {links}
       </div>
       <Link href="/sitemap">Sitemap</Link>
     </>

--- a/src/lib/components/navbar/member.tsx
+++ b/src/lib/components/navbar/member.tsx
@@ -1,8 +1,8 @@
-import type { FunctionComponent } from 'react';
+import type { FunctionComponent } from "react";
 
-import Link from 'next/link';
+import Link from "next/link";
 
-import styles from './index.module.css';
+import styles from "./index.module.css";
 
 export const Member: FunctionComponent = () => (
   <div className={`${styles.row} ${styles.desktoplinks}`}>

--- a/src/lib/hooks/auth/index.tsx
+++ b/src/lib/hooks/auth/index.tsx
@@ -1,23 +1,20 @@
-'use client';
+"use client";
 
-import type { User } from 'lib/models';
-
-import { useState, useEffect, useCallback } from 'react';
-import {
-  getCookie, setCookie, deleteCookie, hasCookie,
-} from 'cookies-next';
+import { useState, useEffect, useCallback } from "react";
+import { getCookie, setCookie, deleteCookie, hasCookie } from "cookies-next";
+import type { User } from "lib/models";
 
 export const useToken = () => {
   const [token, setToken] = useState<string | null>(
-    hasCookie('algurado/token') ? getCookie('algurado/token')! : null,
+    hasCookie("algurado/token") ? getCookie("algurado/token")! : null
   );
 
   useEffect(() => {
     if (token === null) {
-      return deleteCookie('algurado/token');
+      return deleteCookie("algurado/token");
     }
 
-    setCookie('algurado/token', token);
+    setCookie("algurado/token", token);
   }, [token]);
 
   return { token, setToken };
@@ -25,17 +22,15 @@ export const useToken = () => {
 
 export const useUser = () => {
   const [user, setUser] = useState<User | null>(
-    hasCookie('algurado/user')
-      ? JSON.parse(getCookie('algurado/user')!)
-      : null,
+    hasCookie("algurado/user") ? JSON.parse(getCookie("algurado/user")!) : null
   );
 
   useEffect(() => {
     if (user === null) {
-      return deleteCookie('algurado/user');
+      return deleteCookie("algurado/user");
     }
 
-    setCookie('algurado/user', user);
+    setCookie("algurado/user", user);
   }, [user]);
 
   return { user, setUser };
@@ -50,10 +45,10 @@ export const useValidate = async () => {
     let newToken: string | null = null;
 
     try {
-      const response = await fetch('api/v1/auth', {
-        method: 'GET',
+      const response = await fetch("api/v1/auth", {
+        method: "GET",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
           Authorization: `Bearer ${token}`,
         },
       });
@@ -62,10 +57,7 @@ export const useValidate = async () => {
         const data = await response.json();
 
         newUser = data.user as User;
-        newToken = response.headers
-          .get('Authorization')
-          ?.split(' ')[1]
-                    ?? null;
+        newToken = response.headers.get("Authorization")?.split(" ")[1] ?? null;
       }
     } catch (error) {}
 

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -1,1 +1,1 @@
-export * from './auth';
+export * from "./auth";

--- a/src/lib/models/index.ts
+++ b/src/lib/models/index.ts
@@ -1,2 +1,2 @@
-export * from './user';
-export * from './task';
+export * from "./user";
+export * from "./task";

--- a/src/lib/models/task.ts
+++ b/src/lib/models/task.ts
@@ -1,7 +1,21 @@
 export type Task = {
-    slug: string
-    title: string
-    description?: string
-    statement: string
-    max_points: number
-}
+  slug: string;
+  title: string;
+  description?: string;
+  statement: string;
+  max_points: number;
+};
+
+export type File = {
+  id: string;
+  name: string;
+  size: number;
+  blob_url: string;
+};
+
+export type Script = {
+  id: string;
+  file_id: string;
+  language_code: string;
+  runtime_args: string;
+};

--- a/src/lib/models/user.ts
+++ b/src/lib/models/user.ts
@@ -1,8 +1,8 @@
 export type User = {
-    email: string
-    username: string
-    hashed_password: string
-    created_at: Date
-    school?: string
-    name?: string
-}
+  email: string;
+  username: string;
+  hashed_password: string;
+  created_at: Date;
+  school?: string;
+  name?: string;
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,16 +1,18 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from "next/server";
 
 export const middleware = (request: NextRequest) => {
   const headers = new Headers(request.headers);
 
-  headers.set('Content-Type', 'application/json');
+  headers.set("Content-Type", "application/json");
   headers.set(
-    'Access-Control-Allow-Origin',
+    "Access-Control-Allow-Origin",
     `
       https://hurado.ncisomendoza.com,
       https://dev.hurado.ncisomendoza.com,
       localhost:10000
-    `.trim().replace(/\s+/g, ' '),
+    `
+      .trim()
+      .replace(/\s+/g, " ")
   );
 
   return NextResponse.next({


### PR DESCRIPTION
* ESLint is deprecating their formatting rules (managing whitespaces, single quotes, etc)
* Prettier seems to now be the de facto standard, so we're using that
* Also got rid of airbnb styling rules. It seemed more annoying than productive with prettier in the picture. 
* Now we double quote bois cause Prettier had it as default (and it seemed unimportant either way)