### PR TITLE
Implement contests model, add constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,4 @@ You should be seeing the following:
 - [Angelu Garcia](https://github.com/devByGelu)
 - [The Boy (alias)](https://github.com/RedBlazerFlame)
 - [Davis Magpantay](https://github.com/dexva)
+- [Clyde Jallorina](https://github.com/clydejallorina)

--- a/src/db/migrations/20240320074757_initial_migration.ts
+++ b/src/db/migrations/20240320074757_initial_migration.ts
@@ -24,14 +24,14 @@ export async function up(knex: Knex): Promise<void> {
         table.text("statement").notNullable();
         table.decimal("score_max", 10, 4).notNullable().defaultTo(100.0);
         table.text("mvp_output"); // Delete this later. It's just for making progress
-        table.float("time_limit").defaultTo(2.0); // in seconds
+        table.float("time_limit").checkPositive("tasks_time_limit_checkPositive").defaultTo(2.0); // in seconds
         table.integer("memory_limit").unsigned().defaultTo(100000); // in bytes
         table.index("slug");
       })
       .createTable("files", (table) => {
         table.uuid("id").primary().defaultTo(knex.raw("uuid_generate_v4()"));
         table.text("name").notNullable();
-        table.integer("size").notNullable();
+        table.integer("size").unsigned().notNullable();
         table.text("url");
       })
       .createTable("scripts", (table) => {
@@ -70,10 +70,10 @@ export async function up(knex: Knex): Promise<void> {
         table.timestamp("created_at").defaultTo(knex.fn.now());
         table.text("verdict");
         table.integer("raw_score");
-        table.integer("running_time_ms");
-        table.integer("running_memory_byte");
-        table.integer("compile_time_ms");
-        table.integer("compile_memory_byte");
+        table.integer("running_time_ms").unsigned();
+        table.integer("running_memory_byte").unsigned();
+        table.integer("compile_time_ms").unsigned();
+        table.integer("compile_memory_byte").unsigned();
         table.index(["submission_id", "created_at"]);
       })
       .createTable("contests", (table) => {

--- a/src/db/migrations/20240320074757_initial_migration.ts
+++ b/src/db/migrations/20240320074757_initial_migration.ts
@@ -23,16 +23,16 @@ export async function up(knex: Knex): Promise<void> {
         table.text("title").notNullable();
         table.text("description");
         table.text("statement").notNullable();
-        table.decimal("score_max", 10, 4).notNullable().defaultTo(100.0);
+        table.decimal("score_max", 10, 4).notNullable();
         table.text("mvp_output"); // Delete this later. It's just for making progress
-        table.float("time_limit").checkPositive("tasks_time_limit_checkPositive").defaultTo(2.0); // in seconds
-        table.integer("memory_limit").unsigned().defaultTo(100000); // in bytes
+        table.float("time_limit_s").checkPositive("tasks_time_limit_s_check_positive");
+        table.integer("memory_limit_bytes").checkPositive("tasks_memory_limit_bytes_check_positive");
         table.index("slug");
       })
       .createTable("files", (table) => {
         table.uuid("id").primary().defaultTo(knex.raw("uuid_generate_v4()"));
         table.text("name").notNullable();
-        table.integer("size").unsigned().notNullable();
+        table.integer("size").notNullable().checkPositive("files_size_check_positive");
         table.text("url");
       })
       .createTable("scripts", (table) => {
@@ -71,10 +71,10 @@ export async function up(knex: Knex): Promise<void> {
         table.timestamp("created_at").defaultTo(knex.fn.now());
         table.text("verdict");
         table.integer("raw_score");
-        table.integer("running_time_ms").unsigned();
-        table.integer("running_memory_byte").unsigned();
-        table.integer("compile_time_ms").unsigned();
-        table.integer("compile_memory_byte").unsigned();
+        table.integer("running_time_ms").checkPositive("results_running_time_ms_check_positive");
+        table.integer("running_memory_byte").checkPositive("results_running_memory_byte_check_positive");
+        table.integer("compile_time_ms").checkPositive("results_compile_time_ms_check_positive");
+        table.integer("compile_memory_byte").checkPositive("results_compile_memory_byte_check_positive");
         table.index(["submission_id", "created_at"]);
       })
       .createTable("contests", (table) => {
@@ -83,7 +83,7 @@ export async function up(knex: Knex): Promise<void> {
         table.text("title").notNullable();
         table.text("description");
         table.uuid("owner_id").notNullable().references("id").inTable("users");
-        table.timestamp("start_time").notNullable().defaultTo(knex.fn.now());
+        table.timestamp("start_time");
         table.timestamp("end_time");
         table.index("slug");
       })

--- a/src/db/migrations/20240320074757_initial_migration.ts
+++ b/src/db/migrations/20240320074757_initial_migration.ts
@@ -10,6 +10,7 @@ export async function up(knex: Knex): Promise<void> {
         table.text("hashed_password").notNullable();
         table.timestamp("created_at").defaultTo(knex.fn.now());
         // TODO: Implement user roles (e.g., admin, user, etc.)
+        table.enum("permission_level", ["admin", "user"]).defaultTo("user");
         table.text("school");
         table.text("name");
         table.text("country");

--- a/src/db/migrations/20240320074757_initial_migration.ts
+++ b/src/db/migrations/20240320074757_initial_migration.ts
@@ -74,6 +74,16 @@ export async function up(knex: Knex): Promise<void> {
         table.integer("compile_memory_byte");
         table.index(["submission_id", "created_at"]);
       })
+      .createTable("contests", (table) => {
+        table.uuid("id").primary().defaultTo(knex.raw("uuid_generate_v4()"));
+        table.text("slug").notNullable().unique();
+        table.text("title").notNullable();
+        table.text("description");
+        table.uuid("owner_id").notNullable().references("id").inTable("users");
+        table.timestamp("start_time").notNullable().defaultTo(knex.fn.now());
+        table.timestamp("end_time");
+        table.index("slug");
+      })
       .alterTable("submissions", (table) => {
         table
           .uuid("official_result_id")
@@ -96,6 +106,7 @@ export async function down(knex: Knex): Promise<void> {
       .dropTable("scripts")
       .dropTable("files")
       .dropTable("users")
-      .dropTable("tasks");
+      .dropTable("tasks")
+      .dropTable("contests");
   });
 }

--- a/src/db/migrations/20240320074757_initial_migration.ts
+++ b/src/db/migrations/20240320074757_initial_migration.ts
@@ -13,6 +13,8 @@ export async function up(knex: Knex): Promise<void> {
         table.text("school");
         table.text("name");
         table.text("country");
+        table.index("username");
+        table.index("email");
       })
       .createTable("tasks", (table) => {
         table.uuid("id").primary().defaultTo(knex.raw("uuid_generate_v4()"));
@@ -22,6 +24,7 @@ export async function up(knex: Knex): Promise<void> {
         table.text("statement").notNullable();
         table.decimal("score_max", 10, 4).notNullable().defaultTo(100.0);
         table.text("mvp_output"); // Delete this later. It's just for making progress
+        table.index("slug");
       })
       .createTable("files", (table) => {
         table.uuid("id").primary().defaultTo(knex.raw("uuid_generate_v4()"));

--- a/src/db/migrations/20240320074757_initial_migration.ts
+++ b/src/db/migrations/20240320074757_initial_migration.ts
@@ -24,6 +24,8 @@ export async function up(knex: Knex): Promise<void> {
         table.text("statement").notNullable();
         table.decimal("score_max", 10, 4).notNullable().defaultTo(100.0);
         table.text("mvp_output"); // Delete this later. It's just for making progress
+        table.float("time_limit").defaultTo(2.0); // in seconds
+        table.integer("memory_limit").unsigned().defaultTo(100000); // in bytes
         table.index("slug");
       })
       .createTable("files", (table) => {

--- a/src/db/migrations/20240320074757_initial_migration.ts
+++ b/src/db/migrations/20240320074757_initial_migration.ts
@@ -20,7 +20,7 @@ export async function up(knex: Knex): Promise<void> {
         table.text("title").notNullable();
         table.text("description");
         table.text("statement").notNullable();
-        table.decimal("score_max", 10, 4).notNullable();
+        table.decimal("score_max", 10, 4).notNullable().defaultTo(100.0);
         table.text("mvp_output"); // Delete this later. It's just for making progress
       })
       .createTable("files", (table) => {


### PR DESCRIPTION
# Contests and Constraints

This PR adds a `contests` model to the schema containing basic info about a contest. This isn't hooked up to anything yet.

This PR also modifies already existing models by setting defaults to a column (`tasks`' `score_max` has a default of 100 now), adding either a constraint or setting them as unsigned. This can be seen on `tasks` (`time_limit` is a float that has a constraint of being positive, `memory_limit` is an unsigned integer) and on `results` where running time and compile time information are all turned into unsigned integers.

I've also added some extra indices in `users` (individual indices for `email` and `username`) and in anything that has a slug column, since it's very likely that we'll be looking for specific tasks by slug probably through the API.

There's also a commit that adds a `permission_level` column that's currently just an enum between `admin` and `user`. This might not be the ideal solution for the platform though so this should probably be thought of again at some point in the future. Maybe we can just add more roles?

This PR also adds me to the contributors list lol